### PR TITLE
docs: skills.sh install (symlink + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This aligns with the Go team's direction. The `modernize` analyzer exists to aut
 
 ## Instructions
 
-The guidelines are available for Junie and Claude Code.
+The guidelines are available for Junie, Claude Code, and other agents via skills.sh.
 
 ### [Junie](https://junie.jetbrains.com)
 
@@ -57,14 +57,6 @@ Run the following commands inside a Claude Code session.
 /plugin install modern-go-guidelines
 ```
 
-Alternatively, install with [skills.sh](https://skills.sh); the same skill package works across agents such as Codex, OpenCode, and Cursor, not only Claude Code.
-
-```bash
-npx skills add JetBrains/go-modern-guidelines
-```
-
-(`--skill use-modern-go` installs only this skill.)
-
 #### Usage
 
 The plugin adds the `/use-modern-go` command. Run it at the start of a session to activate the guidelines:
@@ -84,3 +76,13 @@ If you'd prefer a different target version, just let me know.
 ```
 
 After this, any Go code the agent writes will follow the guidelines.
+
+### Other Agents (via [skills.sh](https://skills.sh))
+
+The same skill package works across agents such as Codex, OpenCode, and Cursor. Install it with:
+
+```bash
+npx skills add JetBrains/go-modern-guidelines
+```
+
+(`--skill use-modern-go` installs only this skill.)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Run the following commands inside a Claude Code session.
 /plugin install modern-go-guidelines
 ```
 
+Alternatively, install with [skills.sh](https://skills.sh); the same skill package works across agents such as Codex, OpenCode, and Cursor, not only Claude Code.
+
+```bash
+npx skills add JetBrains/go-modern-guidelines
+```
+
+(`--skill use-modern-go` installs only this skill.)
+
 #### Usage
 
 The plugin adds the `/use-modern-go` command. Run it at the start of a session to activate the guidelines:

--- a/skills/use-modern-go
+++ b/skills/use-modern-go
@@ -1,0 +1,1 @@
+../claude/modern-go-guidelines/skills/use-modern-go


### PR DESCRIPTION
Adds a conventional top-level `skills/` entrypoint and documents `npx skills add` for Codex, OpenCode, Cursor, and other [skills CLI](https://github.com/vercel-labs/skills)–compatible agents (see #4). **Diff: 2 files** (`README.md`, `skills/use-modern-go` symlink)—no edits to `SKILL.md` or `.claude-plugin` JSON.

## skills.sh install: before → after

**Before** — deep tree URL to the skill directory:

```bash
npx skills add https://github.com/JetBrains/go-modern-guidelines/tree/main/claude/modern-go-guidelines/skills/use-modern-go
```

**After** — short repo form (same skill; optional `--skill use-modern-go`):

```bash
npx skills add JetBrains/go-modern-guidelines
```

## What changed

| File | Change |
|------|--------|
| `skills/use-modern-go` | Symlink → `claude/modern-go-guidelines/skills/use-modern-go` (no duplicate `SKILL.md`) |
| `README.md` | `npx skills add …` under Claude Code → Installation |

## Not in this PR

- `claude/.../SKILL.md` — unchanged  
- `.claude-plugin/marketplace.json`, `claude/.../.claude-plugin/plugin.json` — unchanged (the CLI discovers the skill via the `skills/` path above)

## Commits

- `chore(skills): add skills/ symlink for CLI discovery`
- `docs: document skills.sh install for other agents`