### PR TITLE
Fix six examples that give a different result than the code they replace

### DIFF
--- a/internal/guidelines/guidelines.json
+++ b/internal/guidelines/guidelines.json
@@ -195,8 +195,8 @@
   {
     "id": "strings_bytes_cut_last",
     "since_version": "1.27",
-    "guideline": "Use strings.CutLast and bytes.CutLast instead of LastIndex plus manual slicing around the last separator.",
-    "details": "CutLast splits around the final separator and returns before, after, and found. It removes LastIndex checks and manual separator-length slicing.",
+    "guideline": "Use strings.CutLast and bytes.CutLast instead of LastIndex plus manual slicing around the last separator. When the separator is absent CutLast returns the whole input as before and an empty after, so check found before you use them.",
+    "details": "CutLast splits around the final separator and returns before, after, and found. It removes LastIndex checks and manual separator-length slicing. When the separator is absent CutLast returns s, an empty after, and false. That is the opposite of the usual LastIndex fallback, which treats the whole input as the trailing part, so keep the not-found branch explicit.",
     "examples": [
       {
         "before": [
@@ -207,7 +207,10 @@
           "dir, file := path[:i], path[i+1:]"
         ],
         "after": [
-          "dir, file, found := strings.CutLast(path, \"/\")"
+          "dir, file, found := strings.CutLast(path, \"/\")",
+          "if !found {",
+          "  return \"\", path, false",
+          "}"
         ]
       },
       {
@@ -219,7 +222,10 @@
           "name, value := line[:i], line[i+1:]"
         ],
         "after": [
-          "name, value, found := bytes.CutLast(line, []byte(\":\"))"
+          "name, value, found := bytes.CutLast(line, []byte(\":\"))",
+          "if !found {",
+          "  return nil, line, false",
+          "}"
         ]
       }
     ]
@@ -702,8 +708,8 @@
   {
     "id": "min_max",
     "since_version": "1.21",
-    "guideline": "Use built-in min and max instead of handwritten comparisons.",
-    "details": "The min and max built-ins express ordered comparisons directly. They remove branch boilerplate when the logic is simply choosing the smaller or larger value.",
+    "guideline": "Use built-in min and max instead of handwritten comparisons. For floating point values min and max propagate NaN where an if comparison keeps the running value.",
+    "details": "The min and max built-ins express ordered comparisons directly. They remove branch boilerplate when the logic is simply choosing the smaller or larger value. For floating point values max(a, b) returns NaN when either operand is NaN, while if b > a { a = b } keeps a. Keep the explicit comparison when NaN must not propagate.",
     "examples": [
       {
         "before": [
@@ -842,8 +848,8 @@
   {
     "id": "slices_max_min",
     "since_version": "1.21",
-    "guideline": "Use slices.Max and slices.Min instead of manual loops over ordered values.",
-    "details": "slices.Max and slices.Min capture the common non-empty-slice scan for an ordered maximum or minimum. Keep explicit logic when empty slices or custom comparison rules need special handling.",
+    "guideline": "Use slices.Max and slices.Min instead of manual loops over ordered values. They panic on an empty slice and propagate NaN for floating point values.",
+    "details": "slices.Max and slices.Min capture the common non-empty-slice scan for an ordered maximum or minimum. Keep explicit logic when empty slices or custom comparison rules need special handling. For floating point values they return NaN when the slice holds a NaN, while a manual > scan keeps the running value.",
     "examples": [
       {
         "before": [
@@ -920,7 +926,7 @@
     "id": "slices_clone",
     "since_version": "1.21",
     "guideline": "Use slices.Clone to copy a slice.",
-    "details": "slices.Clone returns a shallow copy of a slice using the standard helper. It is clearer than append-copy boilerplate and preserves nil slices.",
+    "details": "slices.Clone returns a shallow copy of a slice using the standard helper. It is clearer than append-copy boilerplate. slices.Clone(nil) returns nil, but an empty non-nil slice produces an empty non-nil copy where append([]T(nil), values...) produces nil. json.Marshal then writes [] instead of null.",
     "examples": [
       {
         "before": [
@@ -935,8 +941,8 @@
   {
     "id": "maps_clone",
     "since_version": "1.21",
-    "guideline": "Use maps.Clone instead of manual map iteration.",
-    "details": "maps.Clone returns a shallow copy of a map using the standard helper. It preserves nil maps and makes the copy operation explicit.",
+    "guideline": "Use maps.Clone to copy a map. maps.Clone returns nil for a nil map, so a write to the result panics where a make plus range copy would have succeeded.",
+    "details": "maps.Clone returns a shallow copy of a map using the standard helper. It makes the copy operation explicit. Unlike a make plus range copy, it preserves a nil source: maps.Clone(nil) returns a nil map, and a write to that result panics. Keep make when the copy must be writable whatever the source is.",
     "examples": [
       {
         "before": [
@@ -1043,7 +1049,7 @@
     "id": "context_after_func",
     "since_version": "1.21",
     "guideline": "Use context.AfterFunc to run cleanup when a context is canceled.",
-    "details": "context.AfterFunc registers work to run after cancellation and returns a stop function. It avoids starting a goroutine whose only job is to wait on ctx.Done.",
+    "details": "context.AfterFunc registers work to run after cancellation and returns a stop function. It avoids starting a goroutine whose only job is to wait on ctx.Done. The stop function cancels the registration, so call it only when the cleanup must no longer run. Do not defer stop in the enclosing function unless the cleanup is scoped to that function, because the registration then ends as soon as the function returns.",
     "examples": [
       {
         "before": [
@@ -1053,8 +1059,7 @@
           "}()"
         ],
         "after": [
-          "stop := context.AfterFunc(ctx, cleanup)",
-          "defer stop()"
+          "context.AfterFunc(ctx, cleanup)"
         ]
       }
     ]
@@ -1097,7 +1102,7 @@
     "id": "bytes_clone",
     "since_version": "1.20",
     "guideline": "Use bytes.Clone to copy a byte slice.",
-    "details": "bytes.Clone communicates that a new byte slice is required. It avoids append-copy boilerplate and preserves the standard library's nil-slice behavior.",
+    "details": "bytes.Clone communicates that a new byte slice is required. It avoids append-copy boilerplate. bytes.Clone(nil) returns nil, but an empty non-nil slice produces an empty non-nil copy where append([]byte(nil), b...) produces nil. json.Marshal then writes \"\" instead of null.",
     "examples": [
       {
         "before": [
@@ -1240,8 +1245,8 @@
   {
     "id": "bytes_cut",
     "since_version": "1.18",
-    "guideline": "Use bytes.Cut instead of bytes.Index plus manual slicing.",
-    "details": "bytes.Cut returns before, after, and found in one call. It avoids duplicated Index checks and separator-length arithmetic while returning slices of the original byte slice.",
+    "guideline": "Use bytes.Cut instead of bytes.Index plus manual slicing. Cut returns b as before and a nil after when sep is absent, so check found before you use before.",
+    "details": "bytes.Cut returns before, after, and found in one call. It avoids duplicated Index checks and separator-length arithmetic while returning slices of the original byte slice. When sep is absent Cut returns b, a nil after, and false, so a caller that ignores found reads the whole input as before.",
     "examples": [
       {
         "before": [
@@ -1252,7 +1257,10 @@
           "before, after := b[:i], b[i+len(sep):]"
         ],
         "after": [
-          "before, after, found := bytes.Cut(b, sep)"
+          "before, after, found := bytes.Cut(b, sep)",
+          "if !found {",
+          "  return nil, nil, false",
+          "}"
         ]
       }
     ]
@@ -1260,8 +1268,8 @@
   {
     "id": "strings_cut",
     "since_version": "1.18",
-    "guideline": "Use strings.Cut instead of strings.Index plus manual slicing.",
-    "details": "strings.Cut returns before, after, and found in one call. It makes split-at-first-separator logic explicit and removes manual Index checks and slicing.",
+    "guideline": "Use strings.Cut instead of strings.Index plus manual slicing. Cut returns s as before and an empty after when sep is absent, so check found before you use before.",
+    "details": "strings.Cut returns before, after, and found in one call. It makes split-at-first-separator logic explicit and removes manual Index checks and slicing. When sep is absent Cut returns s, an empty after, and false, so a caller that ignores found reads the whole input as before.",
     "examples": [
       {
         "before": [
@@ -1272,7 +1280,10 @@
           "key, value := s[:i], s[i+1:]"
         ],
         "after": [
-          "key, value, found := strings.Cut(s, \":\")"
+          "key, value, found := strings.Cut(s, \":\")",
+          "if !found {",
+          "  return \"\", \"\", false",
+          "}"
         ]
       }
     ]

--- a/internal/guidelines/guidelines_test.go
+++ b/internal/guidelines/guidelines_test.go
@@ -40,7 +40,7 @@ func TestListForGo127(t *testing.T) {
 	for _, want := range []string{
 		"generic_methods: Use generic methods instead of package-level generic helper functions when the operation naturally belongs to the type itself.",
 		"promoted_field_literals: Set embedded struct fields directly with promoted field names in Go 1.27+ struct literals instead of constructing the embedded struct explicitly.",
-		"strings_bytes_cut_last: Use strings.CutLast and bytes.CutLast instead of LastIndex plus manual slicing around the last separator.",
+		"strings_bytes_cut_last: Use strings.CutLast and bytes.CutLast instead of LastIndex plus manual slicing around the last separator. When the separator is absent CutLast returns the whole input as before and an empty after, so check found before you use them.",
 		"stdlib_uuid: Use the standard library uuid package instead of third-party libraries or custom UUID implementations when targeting Go 1.27+.",
 		"url_clone: Use net/url URL.Clone and Values.Clone methods to copy URLs and URL values instead of manual copying.",
 	} {
@@ -165,5 +165,33 @@ func TestExplainFormatting(t *testing.T) {
     ptr.Store(cfg)`
 	if output != want {
 		t.Fatalf("explain output mismatch\nwant:\n%s\ngot:\n%s", want, output)
+	}
+}
+
+// TestCutExamplesKeepNotFoundBranch guards the fix for the Cut-family examples.
+// strings.Cut, bytes.Cut, strings.CutLast, and bytes.CutLast do not return zero
+// values when the separator is absent: they return the whole input as before.
+// The "before" snippets of these examples all return on that path, so the
+// "after" snippets must keep the branch, or the rewrite changes the result.
+func TestCutExamplesKeepNotFoundBranch(t *testing.T) {
+	want := map[string]bool{"strings_cut": false, "bytes_cut": false, "strings_bytes_cut_last": false}
+	for _, guideline := range modernGoGuidelines {
+		if _, ok := want[guideline.id]; !ok {
+			continue
+		}
+		want[guideline.id] = true
+		for i, example := range guideline.examples {
+			if !strings.Contains(example.after, "found :=") {
+				t.Fatalf("%s example %d: after snippet no longer binds found:\n%s", guideline.id, i+1, example.after)
+			}
+			if !strings.Contains(example.after, "if !found {") {
+				t.Fatalf("%s example %d: after snippet drops the not-found branch:\n%s", guideline.id, i+1, example.after)
+			}
+		}
+	}
+	for id, seen := range want {
+		if !seen {
+			t.Fatalf("guideline %q not found", id)
+		}
 	}
 }


### PR DESCRIPTION
Six `before` / `after` pairs give a different result than the code they replace. I measured each one with Go 1.27.0. Nothing here is an opinion.

Fixes Part A of #14. Parts B and C of that issue stay open.

## What changes

| Entry | Input | `before` gives | `after` gave |
|---|---|---|---|
| `strings_bytes_cut_last` | `"file.txt"`, sep `/` | `("", "file.txt")` | `("file.txt", "")` |
| `strings_cut` / `bytes_cut` | `"noseparator"`, sep `:` | `("", "")` and returns | `("noseparator", "")` and continues |
| `context_after_func` | cancel after the function returns | cleanup runs | cleanup does not run |
| `maps_clone` | nil source map | a map you can write to | a nil map |
| `min_max` / `slices_max_min` | `[]float64{1, NaN, 5}` | `5` | `NaN` |
| `slices_clone` / `bytes_clone` | `[]int{}` | a nil slice | an empty non-nil slice |

I used two kinds of fix. I chose one per case.

### Snippet fixes, where the rewrite itself is wrong

**`strings_bytes_cut_last`, `strings_cut`, `bytes_cut`.** `Cut` and `CutLast` return the whole input as `before` when the separator is absent. The `before` snippets return zero values and exit on that path. The `after` snippets now keep the guard. Each pair is now equal on every input.

`CutLast` is the worst of the three. For a path with no separator, `dir` and `file` change places. The `before` snippet follows the `filepath.Split` convention. `CutLast` does the opposite. The result changes on a path that looks correct.

`Cut` is smaller. Its `after` snippet already bound `found`. The result changes only for a reader who uses `key` and ignores `found`.

**`context_after_func`.** `defer stop()` removes the registration when the enclosing function returns. The goroutine it replaces lives as long as the context. I removed `defer stop()`. The `details` text now explains what `stop` does.

### Text fixes, where the rewrite is right but the change is not stated

**`maps_clone`.** The old `details` said "It preserves nil maps and makes the copy operation explicit." That statement is true about `maps.Clone`. It does not say that the change from `make` plus `range` to `maps.Clone` changes the nil-source result. The new text says it.

**`min_max`, `slices_max_min`.** `max` and `slices.Max` return NaN when a value is NaN. An `if b > a` comparison keeps the value it already has. This affects floating point values only.

**`slices_clone`, `bytes_clone`.** `Clone(nil)` returns nil, so "preserves nil slices" is true. But an empty non-nil input gives an empty non-nil copy, where `append([]T(nil), v...)` gives nil. `json.Marshal` then writes `[]` in place of `null` for a slice, and `""` in place of `null` for `[]byte`.

Caveats now sit in the summary as well as in `details` for the entries that change a value. `list` prints the summary only.

## How I checked it

- `gofmt -l .`, `go vet ./...` and `go test ./...` are clean on go1.27.0.
- I compiled every replacement snippet and compared it against its `before` code. I used edge inputs: an empty string, a bare separator, a leading separator, and an input with no separator. All results are equal:

```
CutLast "/a/b/c.txt" equal=true    Cut "k:v"         equal=true
CutLast "file.txt"   equal=true    Cut "noseparator" equal=true
CutLast "a/b"        equal=true    Cut ""            equal=true
CutLast ""           equal=true    Cut ":v"          equal=true
CutLast "/"          equal=true    Cut "k:"          equal=true
AfterFunc without defer stop(): cleanup ran = true
```

- `TestCutExamplesKeepNotFoundBranch` holds the three Cut-family guards in place. I tested it in both directions. If I revert one snippet, it reports "after snippet drops the not-found branch". If I restore the snippet, it passes.
- I updated one existing expectation: the `strings_bytes_cut_last` summary in `TestListForGo127`.

## Overlap with #13

#13 is open against the same file. It changes a different set of entries. But it also reformats every snippet to tab indentation, so the two branches will conflict.

This branch follows current `main`, which uses spaces. I am happy to rebase on top of #13 after it lands.
