### PR TITLE
Fix invalid Go syntax in generic_methods guideline example

### DIFF
--- a/internal/guidelines/guidelines.json
+++ b/internal/guidelines/guidelines.json
@@ -9,32 +9,26 @@
         "before": [
           "type Set[T comparable] map[T]struct{}",
           "",
-          "func Map[T comparable, U any](s Set[T], f func(T) U) []U {",
-          "  out := make([]U, 0, len(s))",
-          "  for value := range s {",
-          "    out = append(out, f(value))",
-          "  }",
-          "  return out",
+          "func Contains[T comparable](s Set[T], v T) bool {",
+          "  _, ok := s[v]",
+          "  return ok",
           "}",
           "",
-          "names := Map(users, func(user User) string {",
-          "  return user.Name",
-          "})"
+          "if Contains(users, target) {",
+          "  // ...",
+          "}"
         ],
         "after": [
           "type Set[T comparable] map[T]struct{}",
           "",
-          "func (s Set[T]) Map[U any](f func(T) U) []U {",
-          "  out := make([]U, 0, len(s))",
-          "  for value := range s {",
-          "    out = append(out, f(value))",
-          "  }",
-          "  return out",
+          "func (s Set[T]) Contains(v T) bool {",
+          "  _, ok := s[v]",
+          "  return ok",
           "}",
           "",
-          "names := users.Map(func(user User) string {",
-          "  return user.Name",
-          "})"
+          "if users.Contains(target) {",
+          "  // ...",
+          "}"
         ]
       }
     ]


### PR DESCRIPTION
## Problem

The `generic_methods` guideline in `internal/guidelines/guidelines.json` shows this "after" example:

```go
func (s Set[T]) Map[U any](f func(T) U) []U { ... }
```

This is **not valid Go**. Methods cannot declare their own type parameters beyond those inherited from the receiver type — only free-standing functions can be generic over additional type parameters. Since this repository's purpose is to teach AI coding agents to emit correct modern Go, shipping a guideline example that fails to compile actively undermines that goal (an agent following this guidance would produce code that doesn't build).

## Fix

Replaced the example with `Contains`, an operation that naturally becomes a method on `Set[T]` without needing any type parameter beyond the receiver's own `T`:

```go
func (s Set[T]) Contains(v T) bool {
  _, ok := s[v]
  return ok
}
```

This is valid Go and still demonstrates the guideline's intent ("use generic methods instead of package-level generic helper functions when the operation naturally belongs to the type itself") without requiring a feature Go doesn't support.