### PR TITLE
Fix wrong Go version detection (#14 part C)

### DIFF
--- a/internal/goversion/goversion.go
+++ b/internal/goversion/goversion.go
@@ -15,6 +15,10 @@ import (
 
 var goVersionInText = regexp.MustCompile(`(?i)(?:^|\s)(?:go)?(\d+\.\d+)`)
 
+// defaultModuleLanguageVersion is the language version the go command assumes
+// for a module whose go.mod has no go directive. See https://go.dev/ref/mod#go-mod-file-go.
+const defaultModuleLanguageVersion = "1.16"
+
 // Resolve returns the normalized Go major.minor version for the given version source.
 func Resolve(filePath, goVersion, develVersion string) (string, error) {
 	explicitVersion := strings.TrimSpace(goVersion)
@@ -92,7 +96,17 @@ func resolveGoVersionFromPath(filePath, develVersion string) (string, error) {
 func resolveGoVersionFromModuleFiles(startDir, develVersion string) (string, bool, error) {
 	if goMod := findUp(startDir, "go.mod"); goMod != "" {
 		version, ok, err := parseGoDirective(goMod, develVersion)
-		return version, ok, err
+		if err != nil {
+			return "", false, err
+		}
+		if !ok {
+			// To the go command a module with no go directive is language
+			// go1.16, whatever the local toolchain or an enclosing go.work
+			// says. Falling through to either of those made the CLI offer
+			// features the go command then refuses to compile.
+			return defaultModuleLanguageVersion, true, nil
+		}
+		return version, true, nil
 	}
 	if goWork := findUp(startDir, "go.work"); goWork != "" {
 		version, ok, err := parseGoDirective(goWork, develVersion)

--- a/internal/goversion/goversion.go
+++ b/internal/goversion/goversion.go
@@ -35,6 +35,19 @@ func Resolve(filePath, goVersion, develVersion string) (string, error) {
 		return resolveGoVersionFromPath(filePath, develVersion)
 	}
 
+	// No path given, so the working directory is the project. README promises
+	// the version is detected from go.mod; without this a bare `list` run
+	// inside a module reported the local toolchain instead.
+	if workingDir, err := os.Getwd(); err == nil {
+		version, ok, err := resolveGoVersionFromModuleFiles(workingDir, develVersion)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return version, nil
+		}
+	}
+
 	return resolveGoToolVersion("local Go toolchain", develVersion)
 }
 

--- a/internal/goversion/goversion_test.go
+++ b/internal/goversion/goversion_test.go
@@ -139,6 +139,78 @@ func TestResolveFromNearestGoMod(t *testing.T) {
 	}
 }
 
+func TestResolveGoModWithoutGoDirectiveUsesLanguageDefault(t *testing.T) {
+	// The Go command reads a module whose go.mod has no go directive as
+	// language go1.16. Falling back to the local toolchain here made the CLI
+	// recommend features the go command then refuses to compile, for example
+	// "new(30) requires go1.26 or later (-lang was set to go1.16)".
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.test/m\n")
+	goFile := filepath.Join(dir, "main.go")
+	writeFile(t, goFile, "package main\n")
+
+	got, err := Resolve(goFile, "", "1.27")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "1.16" {
+		t.Fatalf("Resolve = %q, want %q", got, "1.16")
+	}
+}
+
+func TestResolveGoModPathWithoutGoDirectiveUsesLanguageDefault(t *testing.T) {
+	dir := t.TempDir()
+	goMod := filepath.Join(dir, "go.mod")
+	writeFile(t, goMod, "module example.test/m\n")
+
+	got, err := Resolve(goMod, "", "1.27")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "1.16" {
+		t.Fatalf("Resolve = %q, want %q", got, "1.16")
+	}
+}
+
+func TestResolveGoModWithoutGoDirectiveIgnoresParentGoWork(t *testing.T) {
+	// A go.work above the module does not change the go command's answer: the
+	// member module is still built at go1.16, so the workspace version would be
+	// the wrong one to inherit.
+	dir := t.TempDir()
+	moduleDir := filepath.Join(dir, "m")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "go.work"), "go 1.25\n\nuse ./m\n")
+	writeFile(t, filepath.Join(moduleDir, "go.mod"), "module example.test/m\n")
+	goFile := filepath.Join(moduleDir, "x.go")
+	writeFile(t, goFile, "package m\n")
+
+	got, err := Resolve(goFile, "", "1.27")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "1.16" {
+		t.Fatalf("Resolve = %q, want %q", got, "1.16")
+	}
+}
+
+func TestResolveGoWorkWithoutGoDirectiveFallsBackToToolchain(t *testing.T) {
+	// go.work carries no language-version default of its own, so a workspace
+	// file with no go directive and no go.mod alongside it keeps the existing
+	// toolchain fallback.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.work"), "use ./m\n")
+
+	_, ok, err := resolveGoVersionFromModuleFiles(dir, "1.27")
+	if err != nil {
+		t.Fatalf("resolveGoVersionFromModuleFiles: %v", err)
+	}
+	if ok {
+		t.Fatal("resolveGoVersionFromModuleFiles claimed a version for a go.work with no go directive")
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {

--- a/internal/goversion/goversion_test.go
+++ b/internal/goversion/goversion_test.go
@@ -211,6 +211,41 @@ func TestResolveGoWorkWithoutGoDirectiveFallsBackToToolchain(t *testing.T) {
 	}
 }
 
+func TestResolveWithoutFilePathReadsModuleInWorkingDirectory(t *testing.T) {
+	// README: "Detect the project's Go version from go.mod". A bare `list`
+	// passes no file path, so without this it reported the local toolchain and
+	// offered guidelines the project's own go directive does not allow.
+	dir := t.TempDir()
+	pkgDir := filepath.Join(dir, "pkg")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.test/m\n\ngo 1.21\n")
+	t.Chdir(pkgDir)
+
+	got, err := Resolve("", "", "1.27")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "1.21" {
+		t.Fatalf("Resolve = %q, want %q", got, "1.21")
+	}
+}
+
+func TestResolveWithoutFilePathFallsBackToToolchainOutsideAModule(t *testing.T) {
+	// No go.mod anywhere above the working directory, so the toolchain remains
+	// the only available answer.
+	t.Chdir(t.TempDir())
+
+	got, err := Resolve("", "", "1.27")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !IsMajorMinor(got) {
+		t.Fatalf("Resolve = %q, want a major.minor toolchain version", got)
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {


### PR DESCRIPTION
Fixes **Part C** of #14. Part A is covered by #20, and **Part B has since been fixed upstream by #23** — this PR previously carried a commit for it, and that commit has been dropped on rebase. `guidelines.json` is no longer touched at all.

Two independent commits, one per defect, so either can be dropped without disturbing the other.

Rebased onto `ae7766c`. I re-ran each defect against that exact commit before re-proposing, using Go 1.27.0.

## Part C1 — a `go.mod` with no `go` directive

`resolveGoVersionFromModuleFiles` returned `ok=false` when `parseGoDirective` found no `go` directive, so the caller fell through to `resolveGoToolVersion` and reported the local toolchain.

The go command reads such a module as language go1.16, so the CLI recommended features the go command then refuses to compile:

```
./main.go:6:7: new(30) requires go1.26 or later (-lang was set to go1.16; check go.mod)
```

Two things the fix deliberately does **not** do, both pinned by tests:

- **An enclosing `go.work` does not override it.** The member module still builds at go1.16, so inheriting the workspace version would be a different wrong answer.
- **A `go.work` with no `go` directive keeps the existing toolchain fallback**, since a workspace file carries no language-version default of its own.

## Part C2 — a bare `list` never reads the `go.mod` in the working directory

README line 11: *"Detect the project's Go version from `go.mod`"*. Measured inside a module declaring `go 1.21`:

```
list                   54 guidelines
list --file-path y.go  32 guidelines
```

Now both report 32, and running outside any module still falls back to the toolchain.

@RO-29 called this one arguable and I agree — `SKILL.md` steers agents to `--file-path`, so the shipped flow rarely hits a bare `list`. It is a separate commit so you can drop it if you would rather change the README than the behaviour.

## Verification

Against `ae7766c` with Go 1.27.0:

```
go test ./...
ok  	internal/cli
ok  	internal/goversion
ok  	internal/guidelines
ok  	internal/guidelines/featuresgen
ok  	internal/guidelines/schema
```

All four new tests were run against the unpatched tree first and observed to fail:

```
--- FAIL: TestResolveGoModWithoutGoDirectiveUsesLanguageDefault      Resolve = "1.27", want "1.16"
--- FAIL: TestResolveGoModPathWithoutGoDirectiveUsesLanguageDefault  Resolve = "1.27", want "1.16"
--- FAIL: TestResolveGoModWithoutGoDirectiveIgnoresParentGoWork      Resolve = "1.27", want "1.16"
--- FAIL: TestResolveWithoutFilePathReadsModuleInWorkingDirectory    Resolve = "1.27", want "1.21"
```
