### PR TITLE
fix: correct strings_clone since_version from 1.20 to 1.18 (fixes #14)

### DIFF
--- a/internal/guidelines/guidelines.json
+++ b/internal/guidelines/guidelines.json
@@ -1079,7 +1079,7 @@
   },
   {
     "id": "strings_clone",
-    "since_version": "1.20",
+    "since_version": "1.18",
     "guideline": "Use strings.Clone to copy a string without retaining shared backing memory.",
     "details": "strings.Clone forces a string copy. Use it when retaining a small string derived from a much larger string would otherwise keep the larger backing memory alive.",
     "examples": [

--- a/internal/guidelines/guidelines.json
+++ b/internal/guidelines/guidelines.json
@@ -1078,22 +1078,6 @@
     ]
   },
   {
-    "id": "strings_clone",
-    "since_version": "1.18",
-    "guideline": "Use strings.Clone to copy a string without retaining shared backing memory.",
-    "details": "strings.Clone forces a string copy. Use it when retaining a small string derived from a much larger string would otherwise keep the larger backing memory alive.",
-    "examples": [
-      {
-        "before": [
-          "copied := string([]byte(s))"
-        ],
-        "after": [
-          "copied := strings.Clone(s)"
-        ]
-      }
-    ]
-  },
-  {
     "id": "bytes_clone",
     "since_version": "1.20",
     "guideline": "Use bytes.Clone to copy a byte slice.",
@@ -1253,6 +1237,22 @@
         ],
         "after": [
           "before, after, found := bytes.Cut(b, sep)"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "strings_clone",
+    "since_version": "1.18",
+    "guideline": "Use strings.Clone to copy a string without retaining shared backing memory.",
+    "details": "strings.Clone forces a string copy. Use it when retaining a small string derived from a much larger string would otherwise keep the larger backing memory alive.",
+    "examples": [
+      {
+        "before": [
+          "copied := string([]byte(s))"
+        ],
+        "after": [
+          "copied := strings.Clone(s)"
         ]
       }
     ]


### PR DESCRIPTION
Fixes part of #14: correct `strings_clone` `since_version` from `1.20` to `1.18`.

`strings.Clone` was added in Go 1.18, as recorded in `$GOROOT/api/go1.18.txt`. The `bytes.Clone` entry correctly uses `1.20` (bytes.Clone was added in Go 1.20). The `FEATURES.md` groups both under a Go 1.20+ heading, which is likely where the incorrect value came from.

This change means `list` for a Go 1.18 or Go 1.19 project will now correctly include the `strings_clone` guideline.