### PR TITLE
fix: reject malformed --go-version values

### DIFF
--- a/internal/goversion/goversion.go
+++ b/internal/goversion/goversion.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
-var goVersionInText = regexp.MustCompile(`(?i)(?:^|\s)(?:go)?(\d+\.\d+)`)
+var strictGoVersionPattern = regexp.MustCompile(`(?i)^(?:go\s+version\s+)?(?:go)?(\d+\.\d+)(?:\.\d+)?(?:\s+.*)?$`)
 
 // Resolve returns the normalized Go major.minor version for the given version source.
 func Resolve(filePath, goVersion, develVersion string) (string, error) {
@@ -177,7 +177,7 @@ func normalizeGoVersion(rawVersion, develVersion string) (string, error) {
 		return develVersion, nil
 	}
 
-	match := goVersionInText.FindStringSubmatch(trimmed)
+	match := strictGoVersionPattern.FindStringSubmatch(trimmed)
 	if len(match) < 2 {
 		return "", fmt.Errorf("cannot parse Go version %q", rawVersion)
 	}

--- a/internal/goversion/goversion_test.go
+++ b/internal/goversion/goversion_test.go
@@ -26,6 +26,22 @@ func TestNormalizeGoVersion(t *testing.T) {
 	}
 }
 
+func TestNormalizeGoVersionStrictRejection(t *testing.T) {
+	invalidVersions := []string{
+		"1.24x",
+		"invalid.ver",
+		"go1.24.foo",
+		"abc1.24",
+	}
+
+	for _, input := range invalidVersions {
+		got, err := normalizeGoVersion(input, "1.27")
+		if err == nil {
+			t.Fatalf("normalizeGoVersion(%q) unexpectedly succeeded and returned %q, want error", input, got)
+		}
+	}
+}
+
 func TestNormalizeGoVersionDevelUsesConfiguredVersion(t *testing.T) {
 	got, err := normalizeGoVersion("devel", "1.99")
 	if err != nil {


### PR DESCRIPTION
- Replace loose regex matching with strictGoVersionPattern anchored to input boundaries
- Reject invalid version strings like '1.24x', 'invalid.ver', and 'abc1.24'
- Add TestNormalizeGoVersionStrictRejection regression tests

************************************************************************************

 ## Summary

  This PR makes validation of the explicit `--go-version` argument stricter.

  Currently, a malformed value containing trailing characters is accepted because the parser extracts a valid-looking version
  substring instead of validating the complete input.

  ## Reproduction

  Environment:
  - Windows amd64
  - Go 1.26.7
  - Upstream commit reviewed: `40781f167719913666fe2a7dc1c77ea6f256df0a`

  ```cmd
  go run . list --go-version=1.24invalid
  echo %ERRORLEVEL%

  Current behavior
  The value is interpreted as Go 1.24.
  Go 1.24 guidelines are printed.
  The command exits with code 0.

  Documented valid formats should continue to work:

  1.24
  go1.24.3
  devel
  Changes
  Validate the complete explicit Go-version value instead of accepting a matching substring.
  Add regression coverage for trailing invalid characters.
  Preserve support for valid version formats and Go toolchain output.
  Verification
  cmd

  go test -count=1 ./...
  go vet ./...
  gofmt -l .
  Manual negative case:

  cmd

  go run . list --go-version=1.24invalid
  echo %ERRORLEVEL%
  Expected: parsing error and nonzero exit code.

• The content is good, but the first code block is not closed, so the remaining description will render incorrectly. Use this
  corrected version:

  ## Summary

  This PR makes validation of the explicit `--go-version` argument stricter.

  Currently, a malformed value containing trailing characters is accepted because the parser extracts a valid-looking version
  substring instead of validating the complete input.

  ## Reproduction

  Environment:

  - Windows amd64
  - Go 1.26.7
  - Upstream commit reviewed: `40781f167719913666fe2a7dc1c77ea6f256df0a`

  ```cmd
  go run . list --go-version=1.24invalid
  echo %ERRORLEVEL%

  ## Current behavior

  - The value is interpreted as Go 1.24.
  - Go 1.24 guidelines are printed.
  - The command exits with code 0.

  ## Expected behavior

  The CLI should reject 1.24invalid as malformed and return a nonzero exit code.

  Documented valid formats should continue to work:

  - 1.24
  - go1.24.3
  - devel

  ## Changes

  - Validate the complete explicit Go-version value instead of accepting a matching substring.
  - Add regression coverage for trailing invalid characters.
  - Preserve support for valid version formats and Go toolchain output.

  ## Verification

  go test -count=1 ./...
  go vet ./...
  gofmt -l .

  Manual negative case:

  go run . list --go-version=1.24invalid
  echo %ERRORLEVEL%

  Expected result: a parsing error and a nonzero exit code.

  ## Note

  Issue creation is restricted in this repository, so I am submitting this focused PR directly for maintainer review.

 Use the **Changes** section only if your branch already contains those code and test changes.