### PR TITLE
docs(skill): invoke PowerShell wrapper with call operator

### DIFF
--- a/plugin/skills/use-modern-go/SKILL.md
+++ b/plugin/skills/use-modern-go/SKILL.md
@@ -10,7 +10,7 @@ Always write modern, idiomatic Go code. Use the Modern Go Guidelines CLI as the 
 Command:
 
 - Linux or macOS: `sh "<skill-dir>/scripts/run-tool.sh"`
-- Windows PowerShell: `'<skill-dir>\scripts\run-tool.ps1'`
+- Windows PowerShell: `& '<skill-dir>\scripts\run-tool.ps1'`
 
 First run and approvals:
 


### PR DESCRIPTION
## Summary

Prefix the documented Windows PowerShell wrapper path with the call operator (`&`) so PowerShell executes the script instead of parsing the path as a string literal.

## Reproduction

Applied the skill to `harnessclaw/harnessclaw-engine`, the Go repository in the `iflytek-astron` topic (`go 1.26.1`):

- documented command without `&`: PowerShell exits with `ParserError` / `UnexpectedToken` at the `list` argument;
- corrected command with `&`: wrapper exits 0, installs/executes v0.1.1, detects the target file's Go version, and returns the applicable guideline list.

## Validation

- `go test ./internal/cli ./internal/goversion ./internal/guidelines ./internal/guidelines/schema` — pass
- `go test ./...` — all packages pass except the existing CRLF-sensitive `TestFeaturesMarkdownInSync` on this Windows checkout; this PR does not modify `FEATURES.md`, the generator, or guideline data
- `git diff --check` — pass

Closes #25.