### PR TITLE
Surface behavior-change caveats in guideline summaries

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -599,9 +599,9 @@ wg.Wait()
 
 **Category: Context · Go 1.24+ · Impact: High · Modernizer: yes**
 
-Use `t.Context()` when a test function needs a context tied to the test lifetime.
+Use `t.Context()` when a test function needs a context tied to the test lifetime; it is already canceled by the time `t.Cleanup` functions run, so do not pass it to cleanup work.
 
-`t.Context()` returns a context tied to the test lifetime. It removes manual background context setup when helper work should stop as the test is ending.
+`t.Context()` returns a context tied to the test lifetime. It removes manual background context setup when helper work should stop as the test is ending. The context is canceled before registered `t.Cleanup` functions run, so cleanup that needs a live context must create its own.
 
 ### Example
 
@@ -668,9 +668,9 @@ type CacheEntry struct {
 
 **Category: Testing · Go 1.24+ · Impact: Medium · Modernizer: yes**
 
-Use `b.Loop()` for the main loop in benchmark functions.
+Use `b.Loop()` for the main loop in benchmark functions; the iteration count is not known before the loop runs, so a benchmark that sizes fixtures from `b.N` needs reworking rather than a mechanical loop swap.
 
-`b.Loop()` is the modern benchmark loop. It manages benchmark iteration mechanics for you and can remove the need for manual timer control in the benchmark body.
+`b.Loop()` is the modern benchmark loop. It manages benchmark iteration mechanics for you and can remove the need for manual timer control in the benchmark body. `b.N` holds the executed iteration count only after `b.Loop()` returns false, so setup that allocates `b.N` elements before the loop has to be restructured instead of translated line by line.
 
 ### Example
 
@@ -963,7 +963,7 @@ for _, item := range items {
 
 Use `cmp.Or` to pick the first non-zero value from a fallback chain.
 
-`cmp.Or` returns the first non-zero value from its arguments. It is concise for simple fallback chains, but remember that all arguments are evaluated before the call.
+`cmp.Or` returns the first non-zero value from its arguments. All arguments are evaluated before the call, so it is the wrong choice when later entries are expensive or have side effects, and when a zero value such as `false` or `0` is a valid result rather than a missing one.
 
 ### Example
 
@@ -1205,9 +1205,9 @@ index := slices.IndexFunc(items, func(item Item) bool {
 
 **Category: Collections · Go 1.21+ · Impact: High · Modernizer: no**
 
-Use `slices.SortFunc` with `cmp.Compare` instead of `sort.Slice` for typed comparisons.
+Use `slices.SortFunc` with `cmp.Compare` instead of `sort.Slice` for typed comparisons; replace `sort.SliceStable` with `slices.SortStableFunc`, because `slices.SortFunc` is not stable.
 
-`slices.SortFunc` compares typed elements directly, avoiding `sort.Slice` closures that index back into the slice. `cmp.Compare` is the usual comparator for ordered fields.
+`slices.SortFunc` compares typed elements directly, avoiding `sort.Slice` closures that index back into the slice. `cmp.Compare` is the usual comparator for ordered fields. `slices.SortFunc` is not stable, so code that relied on `sort.SliceStable` needs `slices.SortStableFunc` to keep equal elements in their original order.
 
 ### Example
 
@@ -1761,7 +1761,7 @@ buf = fmt.Appendf(buf, "x=%d", x)
 
 Use typed atomics such as `atomic.Bool`, `atomic.Int64`, and `atomic.Pointer[T]` instead of untyped atomic functions.
 
-Typed atomic wrapper values keep the storage and the atomic operations together. They make the value type visible, reduce accidental non-atomic access, and avoid old pointer-alignment pitfalls.
+Typed atomic wrapper values keep the storage and the atomic operations together. They make the value type visible, reduce accidental non-atomic access, and avoid old pointer-alignment pitfalls. Prefer them in new code: replacing a raw `int64` or `unsafe.Pointer` field in an existing type changes its layout and size, and `atomic.Value` differs from `atomic.Pointer[T]` in nil and type handling, so migrate a type deliberately rather than call by call.
 
 ### Example 1
 

--- a/internal/guidelines/guidelines.json
+++ b/internal/guidelines/guidelines.json
@@ -422,8 +422,8 @@
     "modernizer": true,
     "category": "Context",
     "impact": "High",
-    "guideline": "Use `t.Context()` when a test function needs a context tied to the test lifetime.",
-    "details": "`t.Context()` returns a context tied to the test lifetime. It removes manual background context setup when helper work should stop as the test is ending.",
+    "guideline": "Use `t.Context()` when a test function needs a context tied to the test lifetime; it is already canceled by the time `t.Cleanup` functions run, so do not pass it to cleanup work.",
+    "details": "`t.Context()` returns a context tied to the test lifetime. It removes manual background context setup when helper work should stop as the test is ending. The context is canceled before registered `t.Cleanup` functions run, so cleanup that needs a live context must create its own.",
     "examples": [
       {
         "before": [
@@ -477,8 +477,8 @@
     "modernizer": true,
     "category": "Testing",
     "impact": "Medium",
-    "guideline": "Use `b.Loop()` for the main loop in benchmark functions.",
-    "details": "`b.Loop()` is the modern benchmark loop. It manages benchmark iteration mechanics for you and can remove the need for manual timer control in the benchmark body.",
+    "guideline": "Use `b.Loop()` for the main loop in benchmark functions; the iteration count is not known before the loop runs, so a benchmark that sizes fixtures from `b.N` needs reworking rather than a mechanical loop swap.",
+    "details": "`b.Loop()` is the modern benchmark loop. It manages benchmark iteration mechanics for you and can remove the need for manual timer control in the benchmark body. `b.N` holds the executed iteration count only after `b.Loop()` returns false, so setup that allocates `b.N` elements before the loop has to be restructured instead of translated line by line.",
     "examples": [
       {
         "before": [
@@ -703,7 +703,7 @@
     "category": "Utilities",
     "impact": "High",
     "guideline": "Use `cmp.Or` to pick the first non-zero value from a fallback chain.",
-    "details": "`cmp.Or` returns the first non-zero value from its arguments. It is concise for simple fallback chains, but remember that all arguments are evaluated before the call.",
+    "details": "`cmp.Or` returns the first non-zero value from its arguments. All arguments are evaluated before the call, so it is the wrong choice when later entries are expensive or have side effects, and when a zero value such as `false` or `0` is a valid result rather than a missing one.",
     "examples": [
       {
         "before": [
@@ -890,8 +890,8 @@
     "modernizer": false,
     "category": "Collections",
     "impact": "High",
-    "guideline": "Use `slices.SortFunc` with `cmp.Compare` instead of `sort.Slice` for typed comparisons.",
-    "details": "`slices.SortFunc` compares typed elements directly, avoiding `sort.Slice` closures that index back into the slice. `cmp.Compare` is the usual comparator for ordered fields.",
+    "guideline": "Use `slices.SortFunc` with `cmp.Compare` instead of `sort.Slice` for typed comparisons; replace `sort.SliceStable` with `slices.SortStableFunc`, because `slices.SortFunc` is not stable.",
+    "details": "`slices.SortFunc` compares typed elements directly, avoiding `sort.Slice` closures that index back into the slice. `cmp.Compare` is the usual comparator for ordered fields. `slices.SortFunc` is not stable, so code that relied on `sort.SliceStable` needs `slices.SortStableFunc` to keep equal elements in their original order.",
     "examples": [
       {
         "before": [
@@ -1312,7 +1312,7 @@
     "category": "Sync",
     "impact": "Medium",
     "guideline": "Use typed atomics such as `atomic.Bool`, `atomic.Int64`, and `atomic.Pointer[T]` instead of untyped atomic functions.",
-    "details": "Typed atomic wrapper values keep the storage and the atomic operations together. They make the value type visible, reduce accidental non-atomic access, and avoid old pointer-alignment pitfalls.",
+    "details": "Typed atomic wrapper values keep the storage and the atomic operations together. They make the value type visible, reduce accidental non-atomic access, and avoid old pointer-alignment pitfalls. Prefer them in new code: replacing a raw `int64` or `unsafe.Pointer` field in an existing type changes its layout and size, and `atomic.Value` differs from `atomic.Pointer[T]` in nil and type handling, so migrate a type deliberately rather than call by call.",
     "examples": [
       {
         "before": [

--- a/internal/guidelines/guidelines_test.go
+++ b/internal/guidelines/guidelines_test.go
@@ -16,7 +16,7 @@ func TestListForResolvedVersion(t *testing.T) {
 		"cmp_or: Use `cmp.Or` to pick the first non-zero value from a fallback chain.",
 		"loopvar_capture: Do not add redundant loop-variable copies before closures or taking addresses; Go 1.22 gives each iteration its own variables.",
 		"maps_keys_values_iter: Use `maps.Keys` or `maps.Values` directly as iterators instead of manually looping over a map.",
-		"testing_t_context: Use `t.Context()` when a test function needs a context tied to the test lifetime.",
+		"testing_t_context: Use `t.Context()` when a test function needs a context tied to the test lifetime; it is already canceled by the time `t.Cleanup` functions run, so do not pass it to cleanup work.",
 		"json_omitzero: Use `omitzero` on JSON-tagged bool, numeric, struct, and time fields whose zero value should be omitted; keep `omitempty` for empty strings, slices, and maps.",
 	} {
 		if !strings.Contains(output, want) {
@@ -72,7 +72,7 @@ func TestExplainFormatting(t *testing.T) {
     ` + "Use typed atomics such as `atomic.Bool`, `atomic.Int64`, and `atomic.Pointer[T]` instead of untyped atomic functions." + `
 
   Details:
-    Typed atomic wrapper values keep the storage and the atomic operations together. They make the value type visible, reduce accidental non-atomic access, and avoid old pointer-alignment pitfalls.
+    ` + "Typed atomic wrapper values keep the storage and the atomic operations together. They make the value type visible, reduce accidental non-atomic access, and avoid old pointer-alignment pitfalls. Prefer them in new code: replacing a raw `int64` or `unsafe.Pointer` field in an existing type changes its layout and size, and `atomic.Value` differs from `atomic.Pointer[T]` in nil and type handling, so migrate a type deliberately rather than call by call." + `
 
   Examples:
 


### PR DESCRIPTION
Moves the caveats for `testing_t_context`, `testing_b_loop` and `slices_sort_func` out of `details` and into the summary that `list` prints. For `cmp_or` and `atomic_types` only the `details` text is expanded; their summaries are unchanged.

`SKILL.md` tells the agent to call `explain` before skipping a guideline, not before applying one, so a caveat reachable only through `explain` is easy to miss when a guideline is applied mechanically to existing code. Examples: `slices.SortFunc` is not stable, `b.N` is not known before `b.Loop()` runs, and `t.Context()` is already canceled when `t.Cleanup` runs.

Scope was narrowed after measuring the effect on agents (see the comment below). The three summary changes kept are the ones where agents introduced bugs without them. The `cmp_or` and `atomic_types` summary changes showed no measurable effect and were dropped. The `http_servemux_patterns` change was not tested and was dropped from this PR.

This changes what agents read from `list` and `explain`, so it is separate from #13 for independent review. `FEATURES.md` regenerated; `make test` passes.